### PR TITLE
fixing rendering of several pages

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var st = require('st');
 
 // Core screenshot function using phamtonJS
 var browser = function (file, opts, cb) {
-  var width = opts.width;
+  var width = opts.width.slice(0);
   var filename = file.replace(opts.path, '');
   var url = opts.protocol + '://' +  opts.host + ':' + opts.port + '/' + filename;
 


### PR DESCRIPTION
i could not create several pages at once because the width array was referenced and popped until it was empty. now it will clone and available for the next page.