### PR TITLE
added optional zoom support

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,21 +13,28 @@ var browser = function (file, opts, cb) {
 
   phantom.create(function (ph) {
     ph.createPage(function (page) {
-      page.set('zoomFactor', 1);
+      page.set('zoomFactor', opts.zoom);
       var screenshot = function (w) {
         if (!w) {
           ph.exit();
           setTimeout(cb, opts.timeout);
-          width = opts.width;
+          width = opts.width * opts.zoom;
           return;
         }
         page.set('viewportSize', {
-          width: w,
-          height: opts.height
+          width: w * opts.zoom,
+          height: opts.height * opts.zoom
         });
 
         page.open(url, function() {
-          var dest = filename.replace('.html', '') + '-' + w + '.' + opts.type;
+          var dest;
+
+          if ( opts.zoom > 1 ) {
+            dest = filename.replace('.html', '') + '-' + w + '-zoom-' + opts.zoom + '.' + opts.type;
+          } else {
+            dest = filename.replace('.html', '') + '-' + w + '.' + opts.type;
+          }
+          
           // Background problem under self-host server
           page.evaluate(function () {
             var style = document.createElement('style');
@@ -59,6 +66,7 @@ module.exports = function (options) {
   opts.port = options.port || '8080';
   opts.width = options.width || ['1024'];
   opts.height = options.height || '10';
+  opts.zoom = options.zoom || '1';
   opts.type = options.type || 'jpg';
   opts.folder = options.folder || 'screens';
   opts.timeout = options.timeout || 200;

--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,13 @@ Default: 'true'
 
 If plugin should start local web server (otherwise you should start your web server by yourself, or specify host option for some remote server)
 
+#### zoom
+
+Type: `Number`  
+Default: '1'
+
+Zoom level to set the phantom.js browser viewport. Can be used to take 2x, 3x, etc. screen shots. Widths, heights and output file name remain as specified, but the resulting image will be * 'zoom' pixels. E.g. specify 320 width, zoom level 2: output file will be 320px of page content, but at twice the resolution (640px wide).
+
 
 ## Demo
 


### PR DESCRIPTION
Adds support for specifying a zoom level (1,2,3,etc.) for taking retina / hidpi shots. If none specified, defaults to 1 and doesn't affect normal behavior. If 2 or more specified, the viewport is multiplied and the resulting image size is n x zoom level. Filename appended with zoom-'n'.  