### PR TITLE
Zoom option creates filenames with @2x, @3x, etc.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,11 +31,11 @@ var browser = function (file, opts, cb) {
           if ( opts.suffix ){
             dest = filename.replace('.html', '') + '-' + opts.suffix + '.' + opts.type;
           }else if ( opts.zoom > 1 ) {
-            dest = filename.replace('.html', '') + '-' + w + '-zoom-' + opts.zoom + '.' + opts.type;
+              dest = filename.replace('.html', '') + '-' + w + '@' + opts.zoom + 'x.' + opts.type;
           } else {
             dest = filename.replace('.html', '') + '-' + w + '.' + opts.type;
           }
-          
+
           // Background problem under self-host server
           page.evaluate(function () {
             var style = document.createElement('style');

--- a/readme.md
+++ b/readme.md
@@ -112,7 +112,7 @@ Zoom level to set the phantom.js browser viewport. Can be used to take 2x, 3x, e
 Type: `String`  
 Default: 'false'
 
-A custom suffix for output file name, you can use -thumb, -shot, etc. And the output file will named source-file-name + custom-suffix. If no suffix set, will use default suffix.
+A custom suffix for output file name, you can use -thumb, -shot, etc. And the output file will named source-file-name + custom-suffix. If no suffix set, will use default suffix. If `suffix` is set, only the first `width` option will be created.
 
 ## Demo
 


### PR DESCRIPTION
More standardized naming convention (which also works nicely with
InVision via Sync app). Also update Readme to mention that the suffix
option will override multiple width options, creating only a single
screenshot from the first width in the array.
